### PR TITLE
Update API response types

### DIFF
--- a/lib/api-types.d.ts
+++ b/lib/api-types.d.ts
@@ -108,16 +108,27 @@ export interface ComponentSetMetadata {
     containing_page?: PageInfo;
 }
 export interface StyleMetadata {
+    /** The unique identifier of the style */
     key: string;
+    /** The unique identifier of the file which contains the style */
     file_key: string;
+    /** Id of the style node within the figma file */
     node_id: string;
+    /** The type of style */
     style_type: StyleType;
+    /** URL link to the style's thumbnail image */
     thumbnail_url: string;
+    /** Name of the style */
     name: string;
+    /** The description of the style as entered by the publisher */
     description: string;
-    updated_at: string;
+    /** The UTC ISO 8601 time at which the component set was created */
     created_at: string;
+    /** The UTC ISO 8601 time at which the style was updated */
+    updated_at: string;
+    /** The user who last updated the style */
     sort_position: string;
+    /** A user specified order number by which the style can be sorted */
     user: User;
 }
 export interface GetFileResult {
@@ -194,15 +205,26 @@ export interface GetProjectFilesResult {
     files: ProjectFile[];
 }
 export interface GetTeamComponentsResult {
-    components: ComponentMetadata[];
-    cursor: {
-        [x: string]: number;
+    status?: number;
+    error?: Boolean;
+    meta?: {
+        components: ComponentMetadata[];
+        cursor: {
+            [x: string]: number;
+        };
     };
 }
 export interface GetFileComponentsResult {
-    components: ComponentMetadata[];
+    status?: number;
+    error?: Boolean;
+    meta?: {
+        components: ComponentMetadata[];
+    };
 }
-export interface GetComponentResult extends ComponentMetadata {
+export interface GetComponentResult {
+    status?: number;
+    error?: Boolean;
+    meta?: ComponentMetadata;
 }
 export interface GetTeamComponentSetsResult {
     component_sets: ComponentSetMetadata[];
@@ -211,18 +233,39 @@ export interface GetTeamComponentSetsResult {
     };
 }
 export interface GetFileComponentSetsResult {
-    component_sets: ComponentSetMetadata[];
+    status?: number;
+    error?: Boolean;
+    meta?: {
+        component_sets: ComponentSetMetadata[];
+        cursor: {
+            [x: string]: number;
+        };
+    };
 }
-export interface GetComponentSetResult extends ComponentSetMetadata {
+export interface GetComponentSetResult {
+    status?: number;
+    error?: Boolean;
+    meta?: ComponentSetMetadata;
 }
 export interface GetTeamStylesResult {
-    styles: StyleMetadata[];
-    cursor: {
-        [x: string]: number;
+    status?: number;
+    error?: Boolean;
+    meta?: {
+        styles: StyleMetadata[];
+        cursor: {
+            [x: string]: number;
+        };
     };
 }
 export interface GetFileStylesResult {
-    styles: StyleMetadata[];
+    status?: number;
+    error?: Boolean;
+    meta?: {
+        styles: StyleMetadata[];
+    };
 }
-export interface GetStyleResult extends StyleMetadata {
+export interface GetStyleResult {
+    status?: number;
+    error?: Boolean;
+    meta?: StyleMetadata;
 }

--- a/lib/api-types.js.map
+++ b/lib/api-types.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"api-types.js","sourceRoot":"","sources":["../src/api-types.ts"],"names":[],"mappings":";;AA0KC,CAAC;AAQD,CAAC;AAwBD,CAAC;AAOD,CAAC;AAID,CAAC"}
+{"version":3,"file":"api-types.js","sourceRoot":"","sources":["../src/api-types.ts"],"names":[],"mappings":";;AAqLC,CAAC;AAQD,CAAC;AAyBD,CAAC;AAOD,CAAC;AAID,CAAC"}

--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -116,16 +116,27 @@ export interface ComponentSetMetadata {
 }
 
 export interface StyleMetadata {
+    /** The unique identifier of the style */
     key: string,
+    /** The unique identifier of the file which contains the style */
     file_key: string,
+    /** Id of the style node within the figma file */
     node_id: string,
+    /** The type of style */
     style_type: StyleType,
+    /** URL link to the style's thumbnail image */
     thumbnail_url: string,
+    /** Name of the style */
     name: string,
+    /** The description of the style as entered by the publisher */
     description: string,
-    updated_at: string,
+    /** The UTC ISO 8601 time at which the component set was created */
     created_at: string,
+    /** The UTC ISO 8601 time at which the style was updated */
+    updated_at: string,
+    /** The user who last updated the style */
     sort_position: string,
+    /** A user specified order number by which the style can be sorted */
     user: User,
 }
 
@@ -185,7 +196,8 @@ export interface GetCommentsResult {
     comments: Comment[]
 }
 
-export interface PostCommentResult extends Comment {}
+// This returns the Comment that was successfully posted (see: https://www.figma.com/developers/api#post-comments-endpoint)
+export interface PostCommentResult extends Comment { }
 
 // Nothing is returned from this endpoint (see: https://www.figma.com/developers/api#delete-comments-endpoint)
 export interface DeleteCommentsResult { }
@@ -217,15 +229,27 @@ export interface GetProjectFilesResult {
 // -----------------------------------------------------------------
 
 export interface GetTeamComponentsResult {
-    components: ComponentMetadata[],
-    cursor: { [x: string]: number },
+    status?: number,
+    error?: Boolean,
+    meta?: {
+        components: ComponentMetadata[],
+        cursor: { [x: string]: number },
+    },
 }
 
 export interface GetFileComponentsResult {
-    components: ComponentMetadata[],
+    status?: number,
+    error?: Boolean,
+    meta?: {
+        components: ComponentMetadata[],
+    },
 }
 
-export interface GetComponentResult extends ComponentMetadata { }
+export interface GetComponentResult {
+    status?: number,
+    error?: Boolean,
+    meta?: ComponentMetadata,
+}
 
 export interface GetTeamComponentSetsResult {
     component_sets: ComponentSetMetadata[],
@@ -233,18 +257,39 @@ export interface GetTeamComponentSetsResult {
 }
 
 export interface GetFileComponentSetsResult {
-    component_sets: ComponentSetMetadata[],
+    status?: number,
+    error?: Boolean,
+    meta?: {
+        component_sets: ComponentSetMetadata[],
+        cursor: { [x: string]: number },
+    },
 }
 
-export interface GetComponentSetResult extends ComponentSetMetadata { }
+export interface GetComponentSetResult {
+    status?: number,
+    error?: Boolean,
+    meta?: ComponentSetMetadata,
+}
 
 export interface GetTeamStylesResult {
-    styles: StyleMetadata[],
-    cursor: { [x: string]: number },
+    status?: number,
+    error?: Boolean,
+    meta?: {
+        styles: StyleMetadata[],
+        cursor: { [x: string]: number },
+    },
 }
 
 export interface GetFileStylesResult {
-    styles: StyleMetadata[],
+    status?: number,
+    error?: Boolean,
+    meta?: {
+        styles: StyleMetadata[],
+    },
 }
 
-export interface GetStyleResult extends StyleMetadata {}
+export interface GetStyleResult {
+    status?: number,
+    error?: Boolean,
+    meta?: StyleMetadata,
+}


### PR DESCRIPTION
Comparing the types declared in the `apy-types.ds` file and the ones described on the [Figma.com](https://www.figma.com/developers/api) website, I have noticed there are some differences, expecially for the "Components and styles" group.

In this PR I have updated the types definition. Please double check that everything is OK. (*) 
Also, I have noticed that some of the definitions for the "Figma files" group are slightly different, but I don't know them enough to be confident to change them, in case you know better please update them as well.

_* it would be great to have some form of tests, so it's safer to do some code refactoring like this, without worrying to break something, maybe I'll open a PR to discuss some ideas that I have about it._