### PR TITLE
Add `isFixed` property to `Node`

### DIFF
--- a/src/ast-types.ts
+++ b/src/ast-types.ts
@@ -908,6 +908,7 @@ export type Node<NType extends NodeType = NodeType> = {
     type: NType;
     pluginData: any;
     sharedPluginData: any;
+    isFixed?: boolean;
 } & NodeTypes[NType];
 
 export function isNodeType<NType extends NodeType, R = Node<NType>>(node: Node<any>, type: NType): node is R {


### PR DESCRIPTION
`isFixed` indicates if a node is a fixed child (default is `false`). It's not part if the Figma API documentation but it's part of the node structure.