### PR TITLE
fix: make getImageApi scale optional

### DIFF
--- a/lib/api-funcs.d.ts
+++ b/lib/api-funcs.d.ts
@@ -48,9 +48,9 @@ export declare function getImageApi(this: ApiClass, fileKey: string, opts: {
     /** A comma separated list of node IDs to render */
     ids: string;
     /** A number between 0.01 and 4, the image scaling factor */
-    scale: number;
+    scale?: number;
     /** A string enum for the image output format */
-    format: 'jpg' | 'png' | 'svg' | 'pdf';
+    format?: 'jpg' | 'png' | 'svg' | 'pdf';
     /** Whether to include id attributes for all SVG elements. `Default: false` */
     svg_include_id?: boolean;
     /** Whether to simplify inside/outside strokes and use stroke attribute if possible instead of <mask>. `Default: true` */

--- a/src/api-funcs.ts
+++ b/src/api-funcs.ts
@@ -89,9 +89,9 @@ export function getImageApi(this: ApiClass,
         /** A comma separated list of node IDs to render */
         ids: string,
         /** A number between 0.01 and 4, the image scaling factor */
-        scale: number,
+        scale?: number,
         /** A string enum for the image output format */
-        format: 'jpg'|'png'|'svg'|'pdf',
+        format?: 'jpg'|'png'|'svg'|'pdf',
         /** Whether to include id attributes for all SVG elements. `Default: false` */
         svg_include_id?: boolean,
         /** Whether to simplify inside/outside strokes and use stroke attribute if possible instead of <mask>. `Default: true` */


### PR DESCRIPTION
According to the [Figma REST API documentation](https://www.figma.com/developers/api#get-images-endpoint), the `scale` and `format` query params are optional for the images endpoint. This updates the `getImageApi` function's types to reflect this.